### PR TITLE
Change the 'Previous Talks' info

### DIFF
--- a/src/partials/info.html
+++ b/src/partials/info.html
@@ -19,7 +19,7 @@
         </div>
     </section>
     <section class="col-md-6">
-        <h4>Previous Talks</h4> {{#each nextEvent.talks}}
+        <h4>Previous Talks</h4> {{#each previousTalks}}
         <div class="row">
             <div class="col-xs-12">
                 <b class="title">{{name}}</b>


### PR DESCRIPTION
This PR is for the issue #6. It adds a new global var called previousTalks which holds the 10 previous talks. I think that there is too much inforamtion in the template if the description is steted to the talk, because for 10 talks with long descriptions gets large very fast. I think it should only contain the date, the title and a link to the full description (issue  #4 which i'm also looking at it jeje).